### PR TITLE
Bug artistreducer

### DIFF
--- a/src/pages/CustomizeProfile.js
+++ b/src/pages/CustomizeProfile.js
@@ -74,6 +74,7 @@ export function CustomizeProfile() {
       })
     }
     else {
+      dispatch(cleanIsUpdate())
       dispatch(getLoggedArtist())
     }
 }, [isUpdate, dispatch, history] );

--- a/src/store/artistReducer.js
+++ b/src/store/artistReducer.js
@@ -265,7 +265,8 @@ function artistReducer(state = initialState, action) {
     case CLEAN_ISUPDATE:
       return {
         ...state,
-        isUpdate: false
+        isUpdate: false,
+        isUpdating: false
       }
     case LOGOUT_ARTIST:
       return initialState


### PR DESCRIPTION
# Bug with isUpdating state in artistReducer 

- Add dispatch to cleanIsUpdate function just after loading the customizeProfile page, in order to reset isUpdate and isUpdating states.
- Set isUpdating to false in CLEAN_ISUPDATE action.
- Both changes were made so when the user updates his or her profile, and wishes to go to Customize Profile page it doesn't crash.
